### PR TITLE
Update docs on apis enablement and region selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ The code is deployed using [Terraform](https://www.terraform.io/).
      cloudfunctions.googleapis.com \
      cloudresourcemanager.googleapis.com \
      googleads.googleapis.com \
-     iam.googleapis.com
+     iam.googleapis.com \
+     secretmanager.googleapis.com
    ```
 
 ### Terraform
@@ -64,7 +65,9 @@ terraform init -backend-config="bucket=[BUCKET_NAME_FROM_STEP2]"
 terraform apply --var-file example.tfvars
 ```
 
-## Code formatting
+## Contributing
+
+### Code formatting
 
 The code is formatted using [yapf](https://github.com/google/yapf). After making
 a change, before submitting the code please do the following:

--- a/terraform/example.tfvars
+++ b/terraform/example.tfvars
@@ -1,7 +1,8 @@
 #The Google Cloud project ID used for this code.
 project_id = ""
 # The region where you would like to store data in BigQuery and host the Cloud
-# functions, e.g. europe-west2
+# functions, e.g. europe-west2. Please note: Region selected needs to support Cloud Scheduler. 
+# Up to date information on region support can be found at https://cloud.google.com/about/locations
 region = ""
 # These next variables are for pulling data from Google Ads. Read:
 # https://developers.google.com/google-ads/api/docs/get-started/introduction


### PR DESCRIPTION
Updates:
- include enabling secret manager on step 9
- Included note that region selected should support Cloud Scheduler (europe-west4  for instance doesn't support it - https://cloud.google.com/about/locations#europe)