### PR TITLE
Update LatestAdPolicyData view to stop adding multiple rows.

### DIFF
--- a/bigquery/views/latest_ad_policy_data.sql
+++ b/bigquery/views/latest_ad_policy_data.sql
@@ -24,7 +24,8 @@ SELECT
 FROM
   `${BQ_DATASET}.AdPolicyData` AS AdPolicyData
 LEFT JOIN
-  `${BQ_DATASET}.Ocid` AS Ocid ON
-  Ocid.account_id = AdPolicyData.customer_id
+  (
+    SELECT DISTINCT account_id, ocid FROM `${BQ_DATASET}.Ocid`
+  ) AS Ocid ON Ocid.account_id = AdPolicyData.customer_id
 WHERE
   EXTRACT(DATE FROM _PARTITIONTIME) = CURRENT_DATE()


### PR DESCRIPTION
If you use `WRITE_APPEND` with the ocid import, then the table contains multiple rows for each ocid.

Therefore when you perform this join you increase the number of rows, which provides incorrect counts in the dashboard.

By pulling through distinct values this change resolves that problem. Distinct should be fine, as there is no reason that these values should change over time.