### PR TITLE
Update NoApprovedAdsAdGroup view to stop adding multiple rows.

### DIFF
--- a/bigquery/views/no_approved_ads_ad_group.sql
+++ b/bigquery/views/no_approved_ads_ad_group.sql
@@ -25,8 +25,9 @@ WITH AdCounts AS (
   FROM
     `${BQ_DATASET}.AdPolicyData` AS AdPolicyData
   LEFT JOIN
-    `${BQ_DATASET}.Ocid` AS Ocid ON
-    Ocid.account_id = AdPolicyData.customer_id
+  (
+    SELECT DISTINCT account_id, ocid FROM `${BQ_DATASET}.Ocid`
+  ) AS Ocid ON Ocid.account_id = AdPolicyData.customer_id
   WHERE
     CAST(_PARTITIONTIME AS DATE) = CURRENT_DATE()
   GROUP BY


### PR DESCRIPTION
Missed this change in [previous PR](https://github.com/google-marketing-solutions/ads-policy-monitor/pull/6), it also impacts this view.
