### PR TITLE
Add clicks & impressions metrics to policy data

### DIFF
--- a/bigquery/schema/ad_policy_data_schema.json
+++ b/bigquery/schema/ad_policy_data_schema.json
@@ -73,5 +73,15 @@
       "name": "ad_group_ad_policy_summary_review_status",
       "type": "STRING",
       "mode": "NULLABLE"
+    },
+    {
+      "name": "impressions",
+      "type": "INTEGER",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "clicks",
+      "type": "INTEGER",
+      "mode": "NULLABLE"
     }
 ]

--- a/bigquery/views/no_approved_ads_ad_group.sql
+++ b/bigquery/views/no_approved_ads_ad_group.sql
@@ -21,6 +21,8 @@ WITH AdCounts AS (
     ad_group_id,
     ad_group_name,
     CONCAT("https://ads.google.com/aw/overview?ocid=", Ocid.ocid) AS gads_link,
+    SUM(impressions) AS total_impressions,
+    SUM(clicks) AS total_clicks,
     COUNT(*) AS number_of_ads,
   FROM
     `${BQ_DATASET}.AdPolicyData` AS AdPolicyData

--- a/cloud_functions/ads_policy_monitor/gaql/ad_policy_data.sql
+++ b/cloud_functions/ads_policy_monitor/gaql/ad_policy_data.sql
@@ -26,7 +26,9 @@ SELECT
   ad_group_ad.status,
   ad_group_ad.policy_summary.approval_status,
   ad_group_ad.policy_summary.policy_topic_entries:topic AS ad_group_ad_policy_summary_policy_topic_entries,
-  ad_group_ad.policy_summary.review_status
+  ad_group_ad.policy_summary.review_status,
+  metrics.impressions AS impressions,
+  metrics.clicks AS clicks
 FROM
   ad_group_ad
 WHERE
@@ -35,3 +37,4 @@ WHERE
   AND campaign.primary_status != 'ENDED'
   AND ad_group.status = 'ENABLED'
   AND ad_group_ad.status != 'REMOVED'
+  AND segments.date DURING LAST_30_DAYS

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -87,6 +87,11 @@ resource "google_bigquery_table" "latest_ad_policy_data_report" {
     )
     use_legacy_sql = false
   }
+  lifecycle {
+    replace_triggered_by = [
+      google_bigquery_table.ad_policy_data_table
+    ]
+  }
 }
 
 # CLOUD STORAGE ----------------------------------------------------------------


### PR DESCRIPTION
This change adds two new fields to the Policy table in BQ, clicks and impressions for the last 30 days, and updates the corresponding views.

Adding this data allows you as an advertiser to prioritise which disapproved ads to focus on.