### PR TITLE
Add google group for looker template on requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ You're also able to see insights like when an ad group has no approved ads:
 - Access to the Google Ads API (e.g. developer token, account access), [see
   getting started](https://developers.google.com/google-ads/api/docs/get-started/introduction).
 - Access to Looker Studio or a dashboard solution that can connect to BigQuery.
+  - If you wish to have access to the Looker Studio template provided by Google, please join this group [ads-policy-monitor-template-readers](https://groups.google.com/g/ads-policy-monitor-template-readers).
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You're also able to see insights like when an ad group has no approved ads:
 - Access to the Google Ads API (e.g. developer token, account access), [see
   getting started](https://developers.google.com/google-ads/api/docs/get-started/introduction).
 - Access to Looker Studio or a dashboard solution that can connect to BigQuery.
-  - If you wish to have access to the Looker Studio template provided by Google, please join this group [ads-policy-monitor-template-readers](https://groups.google.com/g/ads-policy-monitor-template-readers).
+  - If you wish to have access to the [Looker Studio template provided by Google](https://lookerstudio.google.com/c/u/0/reporting/13995d1f-741c-40f0-934c-9517e2ffc361/), please join this group [ads-policy-monitor-template-readers](https://groups.google.com/g/ads-policy-monitor-template-readers).
 
 ## Deployment
 


### PR DESCRIPTION
On requirements section, included joining external group if user wish to use the template provided by us.