### PR TITLE
Add link to Looker template dash when deployment is concluded

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -19,6 +19,29 @@
 TFVARS_FILE="./terraform/example.tfvars"
 REGION=$(grep 'region' $TFVARS_FILE | awk -F= '{print $2}' | tr -d '"' | xargs)
 BUCKET_NAME=$(grep 'bucket_name' $TFVARS_FILE | awk -F= '{print $2}' | tr -d '"' | xargs)
+DATASET_ID=$(grep 'bq_output_dataset' $TFVARS_FILE | awk -F= '{print $2}' | tr -d '"' | xargs)
+PROJECT_ID=$(grep 'project_id' $TFVARS_FILE | awk -F= '{print $2}' | tr -d '"' | xargs)
+TEMPLATE_LINK="https://lookerstudio.google.com/reporting/create?\
+c.mode=edit&c.reportId=13995d1f-741c-40f0-934c-9517e2ffc361&\
+r.reportName=Ads%20Policy%20Monitor&ds.*.refreshFields=false&\
+ds.LatestAdPolicyData.connector=bigQuery&\
+ds.LatestAdPolicyData.datasourceName=LatestAdPolicyData&\
+ds.LatestAdPolicyData.projectId=$PROJECT_ID&\
+ds.LatestAdPolicyData.datasetId=$DATASET_ID&\
+ds.LatestAdPolicyData.type=TABLE&\
+ds.LatestAdPolicyData.tableId=LatestAdPolicyData&\
+ds.AdPolicyData.connector=bigQuery&\
+ds.AdPolicyData.datasourceName=AdPolicyData&\
+ds.AdPolicyData.projectId=$PROJECT_ID&\
+ds.AdPolicyData.datasetId=$DATASET_ID&\
+ds.AdPolicyData.type=TABLE&\
+ds.AdPolicyData.tableId=AdPolicyData&\
+ds.NoApprovedAdsAdGroup.connector=bigQuery&\
+ds.NoApprovedAdsAdGroup.datasourceName=NoApprovedAdsAdGroup&\
+ds.NoApprovedAdsAdGroup.projectId=$PROJECT_ID&\
+ds.NoApprovedAdsAdGroup.datasetId=$DATASET_ID&\
+ds.NoApprovedAdsAdGroup.type=TABLE&\
+ds.NoApprovedAdsAdGroup.tableId=NoApprovedAdsAdGroup"
 
 # Get current cloud project ID
 pr=$DEVSHELL_PROJECT_ID
@@ -54,7 +77,15 @@ if [ $? -eq 0 ]; then
   echo "Initializing terraform..."
   cd terraform
   terraform init -backend-config="bucket=$BUCKET_NAME"
-  terraform apply --var-file example.tfvars
+  terraform apply --var-file example.tfvars && {
+      echo -e "\e[32mTerraform apply was successful.\e[0m"
+
+      echo "If you wish to use the Looker templated provided, click the link below to set up your dashboard:"
+      echo -e "\e[36m$TEMPLATE_LINK\e[0m"
+      echo -e "\nPlease note: You need to be part of the readers group as detailed on deployment requirements: https://groups.google.com/g/ads-policy-monitor-template-readers"
+  } || {
+      echo "Terraform apply failed."
+  }
 else
   exit 1
 fi


### PR DESCRIPTION
Included link to Looker dashboard template when terraform deployment successfully finish.

This is the result in the could shell:
![Screenshot 2024-01-15 at 16 50 32](https://github.com/google-marketing-solutions/ads-policy-monitor/assets/3342195/c398c85f-ee22-4933-bbeb-8566938f23ec)
