### PR TITLE
Getting assets from multiple tables for more metrics

### DIFF
--- a/bigquery/schema/asset_policy_data_schema.json
+++ b/bigquery/schema/asset_policy_data_schema.json
@@ -20,11 +20,6 @@
       "mode": "NULLABLE"
     },
     {
-      "name": "asset_name",
-      "type": "STRING",
-      "mode": "NULLABLE"
-    },
-    {
       "name": "asset_source",
       "type": "STRING",
       "mode": "NULLABLE"
@@ -47,6 +42,16 @@
     {
       "name": "asset_policy_summary_approval_status",
       "type": "STRING",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "asset_level",
+      "type": "STRING",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "counts",
+      "type": "INTEGER",
       "mode": "NULLABLE"
     }
 ]

--- a/cloud_functions/ads_policy_monitor/config.json
+++ b/cloud_functions/ads_policy_monitor/config.json
@@ -10,13 +10,14 @@
       "table_name": "AdPolicyData",
       "write_disposition": "WRITE_APPEND",
       "is_builtin": false,
-      "gaql_filename": "ad_policy_data.sql"
+      "gaql_filenames": "ad_policy_data.sql"
     },
     {
       "table_name": "AssetPolicyData",
       "write_disposition": "WRITE_APPEND",
       "is_builtin": false,
-      "gaql_filename": "asset_policy_data.sql"
+      "is_asset_report": true,
+      "gaql_filenames": ["campaign_asset.sql", "ad_group_asset.sql", "customer_asset.sql"]
     }
   ]
 }

--- a/cloud_functions/ads_policy_monitor/gaql/ad_group_asset.sql
+++ b/cloud_functions/ads_policy_monitor/gaql/ad_group_asset.sql
@@ -1,0 +1,37 @@
+-- Copyright 2023 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT 
+  {{ today }} AS event_date,
+  customer.id,
+  customer.descriptive_name,
+  asset.id,
+  asset.source,
+  asset.type,
+  asset.policy_summary.review_status,
+  asset.policy_summary.policy_topic_entries:topic AS asset_policy_summary_policy_topic_entries_topics,
+  asset.policy_summary.approval_status,
+  campaign.id,
+  campaign.status,
+  campaign.primary_status,
+  ad_group.id,
+  ad_group.status
+FROM
+  ad_group_asset
+WHERE
+  customer.status = 'ENABLED'
+  AND asset.policy_summary.approval_status != 'APPROVED'
+  AND campaign.status = 'ENABLED'
+  AND campaign.primary_status != 'ENDED'
+  AND ad_group.status = 'ENABLED'
+  AND segments.date DURING LAST_30_DAYS

--- a/cloud_functions/ads_policy_monitor/gaql/campaign_asset.sql
+++ b/cloud_functions/ads_policy_monitor/gaql/campaign_asset.sql
@@ -1,4 +1,4 @@
--- Copyright 2024 Google LLC
+-- Copyright 2023 Google LLC
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -11,19 +11,24 @@
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
-SELECT
+SELECT 
   {{ today }} AS event_date,
   customer.id,
   customer.descriptive_name,
   asset.id,
-  asset.name,
   asset.source,
   asset.type,
   asset.policy_summary.review_status,
   asset.policy_summary.policy_topic_entries:topic AS asset_policy_summary_policy_topic_entries_topics,
-  asset.policy_summary.approval_status
+  asset.policy_summary.approval_status,
+  campaign.id,
+  campaign.status,
+  campaign.primary_status
 FROM
-  asset
+  campaign_asset
 WHERE
   customer.status = 'ENABLED'
   AND asset.policy_summary.approval_status != 'APPROVED'
+  AND campaign.status = 'ENABLED'
+  AND campaign.primary_status != 'ENDED'
+  AND segments.date DURING LAST_30_DAYS

--- a/cloud_functions/ads_policy_monitor/gaql/customer_asset.sql
+++ b/cloud_functions/ads_policy_monitor/gaql/customer_asset.sql
@@ -1,0 +1,29 @@
+-- Copyright 2023 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT 
+  {{ today }} AS event_date,
+  customer.id,
+  customer.descriptive_name,
+  asset.id,
+  asset.source,
+  asset.type,
+  asset.policy_summary.review_status,
+  asset.policy_summary.policy_topic_entries:topic AS asset_policy_summary_policy_topic_entries_topics,
+  asset.policy_summary.approval_status
+FROM
+  customer_asset
+WHERE
+  customer.status = 'ENABLED'
+  AND asset.policy_summary.approval_status != 'APPROVED'
+  AND segments.date DURING LAST_30_DAYS

--- a/cloud_functions/ads_policy_monitor/google_ads.py
+++ b/cloud_functions/ads_policy_monitor/google_ads.py
@@ -16,7 +16,7 @@ import logging
 import os
 import random
 import sys
-from typing import List
+from typing import List, Dict
 
 from gaarf.api_clients import GoogleAdsApiClient
 from gaarf.builtin_queries import BUILTIN_QUERIES
@@ -39,6 +39,19 @@ GOOGLE_ADS_REFRESH_TOKEN = os.environ.get('GOOGLE_ADS_REFRESH_TOKEN')
 GOOGLE_ADS_CLIENT_ID = os.environ.get('GOOGLE_ADS_CLIENT_ID')
 GOOGLE_ADS_CLIENT_SECRET = os.environ.get('GOOGLE_ADS_CLIENT_SECRET')
 GOOGLE_ADS_DEVELOPER_TOKEN = os.environ.get('GOOGLE_ADS_DEVELOPER_TOKEN')
+
+GROUP_BY_ASSET_POLICY_COLUMNS = [
+    "event_date", 
+    "customer_id", 
+    "customer_descriptive_name", 
+    "asset_id", 
+    "asset_source", 
+    "asset_type", 
+    "asset_policy_summary_review_status", 
+    "asset_policy_summary_policy_topic_entries_topics",
+    "asset_policy_summary_approval_status",
+    "asset_level",
+]
 
 
 def get_ads_client(payload: models.Payload) -> GoogleAdsApiClient:
@@ -95,12 +108,64 @@ def run_gaarf_report(payload: models.Payload,
                                  report_fetcher=report_fetcher,
                                  customer_ids=payload.customer_ids)
 
-    path = f'gaql/{report_config.gaql_filename}'
+    if report_config.is_asset_report: 
+        all_reports = []
+        for gaql_filename in report_config.gaql_filenames:
+            path = f'gaql/{gaql_filename}'
+            all_reports.append(
+                run_query_from_file(
+                    query_path=path,
+                    report_fetcher=report_fetcher,
+                    customer_ids=payload.customer_ids,
+                )
+            )
+        return combine_assets_reports(all_reports)
+
+    path = f'gaql/{report_config.gaql_filenames}'
     return run_query_from_file(
         query_path=path,
         report_fetcher=report_fetcher,
         customer_ids=payload.customer_ids,
     )
+
+
+def combine_assets_reports(gaarf_reports: List[GaarfReport]) -> GaarfReport:
+    """Combine assets reports.
+
+    Args:
+        gaarf_reports: a list of gaarf reports.
+
+    Returns:
+        A GAARF report.
+    """
+    logger.info('Combining Assets reports')
+    combined_assets_report = pd.DataFrame()
+    for report in gaarf_reports:
+        report_df = report.to_pandas()
+
+        if report_df.empty:
+            continue
+        
+        if ("ad_group_id" in report_df.keys() and "campaign_id" in report_df.keys()):
+            report_df["asset_level"] = "Ad Group"
+        elif ("campaign_id" in report_df.keys()):
+            report_df["asset_level"] = "Campaign"
+        else:
+            report_df["asset_level"] = "Account"
+
+        # Convert policy_topic_entries to str (otherwise group by will fail)
+        report_df["asset_policy_summary_policy_topic_entries_topics"] = report_df[
+            "asset_policy_summary_policy_topic_entries_topics"
+            ].apply(lambda x: x if isinstance(x, str) else ' | '.join(x))
+        
+        report_df = (
+            report_df.groupby(GROUP_BY_ASSET_POLICY_COLUMNS)
+            .size()
+            .reset_index(name='counts')
+        )
+        combined_assets_report = pd.concat([combined_assets_report, report_df])
+
+    return GaarfReport.from_pandas(combined_assets_report)
 
 
 def run_builtin_query(query_name: str, report_fetcher: AdsReportFetcher,

--- a/cloud_functions/ads_policy_monitor/google_ads.py
+++ b/cloud_functions/ads_policy_monitor/google_ads.py
@@ -142,7 +142,8 @@ def combine_assets_reports(gaarf_reports: List[GaarfReport]) -> GaarfReport:
     for report in gaarf_reports:
         report_df = report.to_pandas()
 
-        if report_df.empty:
+        # If no results in the report, then skip
+        if report_df.empty or report_df["customer_id"][0] == 0:
             continue
 
         if ("ad_group_id" in report_df.keys() and

--- a/cloud_functions/ads_policy_monitor/google_ads_test.py
+++ b/cloud_functions/ads_policy_monitor/google_ads_test.py
@@ -12,11 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for google_ads.py"""
+
 import random
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from test_data_helper import TEST_AD_GROUP_ASSET_POLICY_DATA
+from test_data_helper import TEST_CAMPAIGN_ASSET_POLICY_DATA
+from test_data_helper import TEST_CUSTOMER_ASSET_POLICY_DATA
+from test_data_helper import TEST_EXPECTED_ASSET_POLICY_REPORT
+from gaarf.report import GaarfReport
 import google_ads
 import models
+import pandas as pd
+from pandas.testing import assert_frame_equal
 
 
 class GoogleAdsTestCase(unittest.TestCase):
@@ -80,6 +90,25 @@ class GoogleAdsTestCase(unittest.TestCase):
     def test_get_google_ads_synthetic_data_missing(self):
         with self.assertRaises(FileNotFoundError):
             google_ads.get_google_ads_synthetic_data('MissingData')
+
+    def test_combine_assets_reports(self):
+        adgroup_gaarf_report = GaarfReport.from_pandas(
+            pd.DataFrame(TEST_AD_GROUP_ASSET_POLICY_DATA)
+        )
+        campaign_gaarf_report = GaarfReport.from_pandas(
+            pd.DataFrame(TEST_CAMPAIGN_ASSET_POLICY_DATA)
+        )
+        customer_gaarf_report = GaarfReport.from_pandas(
+            pd.DataFrame(TEST_CUSTOMER_ASSET_POLICY_DATA)
+        )
+
+        report = google_ads.combine_assets_reports(
+            [adgroup_gaarf_report, campaign_gaarf_report, customer_gaarf_report]
+        )
+
+        results = report.to_pandas()
+        expected_results = pd.DataFrame(TEST_EXPECTED_ASSET_POLICY_REPORT)
+        assert_frame_equal(results, expected_results)
 
 
 if __name__ == '__main__':

--- a/cloud_functions/ads_policy_monitor/google_ads_test.py
+++ b/cloud_functions/ads_policy_monitor/google_ads_test.py
@@ -24,6 +24,8 @@ from test_data_helper import TEST_AD_GROUP_ASSET_POLICY_DATA
 from test_data_helper import TEST_CAMPAIGN_ASSET_POLICY_DATA
 from test_data_helper import TEST_CUSTOMER_ASSET_POLICY_DATA
 from test_data_helper import TEST_EXPECTED_ASSET_POLICY_REPORT
+from test_data_helper import TEST_CUSTOMER_ASSET_POLICY_DATA_EMPTY
+from test_data_helper import TEST_EXPECTED_ASSET_POLICY_REPORT_EMPTY_CUSTOMER
 from gaarf.report import GaarfReport
 
 import google_ads
@@ -106,6 +108,36 @@ class GoogleAdsTestCase(unittest.TestCase):
 
         results = report.to_pandas()
         expected_results = pd.DataFrame(TEST_EXPECTED_ASSET_POLICY_REPORT)
+        assert_frame_equal(results, expected_results)
+
+    def test_combine_assets_reports_empty_customer(self):
+        adgroup_gaarf_report = GaarfReport.from_pandas(
+            pd.DataFrame(TEST_AD_GROUP_ASSET_POLICY_DATA))
+        campaign_gaarf_report = GaarfReport.from_pandas(
+            pd.DataFrame(TEST_CAMPAIGN_ASSET_POLICY_DATA))
+        customer_gaarf_report = GaarfReport.from_pandas(
+            pd.DataFrame(TEST_CUSTOMER_ASSET_POLICY_DATA_EMPTY))
+
+        report = google_ads.combine_assets_reports([
+            adgroup_gaarf_report, campaign_gaarf_report, customer_gaarf_report
+        ])
+
+        results = report.to_pandas()
+        expected_results = pd.DataFrame(
+            TEST_EXPECTED_ASSET_POLICY_REPORT_EMPTY_CUSTOMER)
+        assert_frame_equal(results, expected_results)
+
+    def test_combine_assets_reports_empty(self):
+        adgroup_gaarf_report = GaarfReport.from_pandas(pd.DataFrame())
+        campaign_gaarf_report = GaarfReport.from_pandas(pd.DataFrame())
+        customer_gaarf_report = GaarfReport.from_pandas(pd.DataFrame())
+
+        report = google_ads.combine_assets_reports([
+            adgroup_gaarf_report, campaign_gaarf_report, customer_gaarf_report
+        ])
+
+        results = report.to_pandas()
+        expected_results = GaarfReport.from_pandas(pd.DataFrame()).to_pandas()
         assert_frame_equal(results, expected_results)
 
 

--- a/cloud_functions/ads_policy_monitor/google_ads_test.py
+++ b/cloud_functions/ads_policy_monitor/google_ads_test.py
@@ -12,11 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for google_ads.py"""
+
 import random
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from test_data_helper import TEST_AD_GROUP_ASSET_POLICY_DATA
+from test_data_helper import TEST_CAMPAIGN_ASSET_POLICY_DATA
+from test_data_helper import TEST_CUSTOMER_ASSET_POLICY_DATA
+from test_data_helper import TEST_EXPECTED_ASSET_POLICY_REPORT
+from gaarf.report import GaarfReport
 import google_ads
 import models
+import pandas as pd
+from pandas.testing import assert_frame_equal
 
 
 class GoogleAdsTestCase(unittest.TestCase):
@@ -80,6 +90,22 @@ class GoogleAdsTestCase(unittest.TestCase):
     def test_get_google_ads_synthetic_data_missing(self):
         with self.assertRaises(FileNotFoundError):
             google_ads.get_google_ads_synthetic_data('MissingData')
+
+    def test_combine_assets_reports(self):
+        adgroup_gaarf_report = GaarfReport.from_pandas(
+            pd.DataFrame(TEST_AD_GROUP_ASSET_POLICY_DATA))
+        campaign_gaarf_report = GaarfReport.from_pandas(
+            pd.DataFrame(TEST_CAMPAIGN_ASSET_POLICY_DATA))
+        customer_gaarf_report = GaarfReport.from_pandas(
+            pd.DataFrame(TEST_CUSTOMER_ASSET_POLICY_DATA))
+
+        report = google_ads.combine_assets_reports([
+            adgroup_gaarf_report, campaign_gaarf_report, customer_gaarf_report
+        ])
+
+        results = report.to_pandas()
+        expected_results = pd.DataFrame(TEST_EXPECTED_ASSET_POLICY_REPORT)
+        assert_frame_equal(results, expected_results)
 
 
 if __name__ == '__main__':

--- a/cloud_functions/ads_policy_monitor/models.py
+++ b/cloud_functions/ads_policy_monitor/models.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """The pydantic models & constants for the project."""
-from typing import List, Optional
+from typing import List, Optional, Union
 from pydantic import BaseModel
 
 
@@ -20,8 +20,9 @@ class ReportConfig(BaseModel):
     table_name: str
     write_disposition: str
     is_builtin: bool = False
+    is_asset_report: bool = False
     builtin_query_name: Optional[str] = None
-    gaql_filename: Optional[str] = None
+    gaql_filenames: Optional[Union[str, List[str]]] = None
 
 
 class Payload(BaseModel):

--- a/cloud_functions/ads_policy_monitor/test_data_helper.py
+++ b/cloud_functions/ads_policy_monitor/test_data_helper.py
@@ -1,0 +1,150 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Constants file for unit tests"""
+
+TEST_AD_GROUP_ASSET_POLICY_DATA = {
+    'event_date': ['2023-10-26', '2023-10-26', '2023-10-26'],
+    'customer_id': [12345, 12345, 12345],
+    'customer_descriptive_name': ['Customer A', 'Customer A', 'Customer A'],
+    'asset_id': [11, 21, 21],
+    'asset_source': ['ADVERTISER', 'ADVERTISER', 'ADVERTISER'],
+    'asset_type': ['CALLOUT', 'CALLOUT', 'CALLOUT'],
+    'asset_policy_summary_review_status': ['REVIEWED', 'REVIEWED', 'REVIEWED'],
+    'asset_policy_summary_policy_topic_entries_topics': [
+        ['TRADEMARKS_IN_AD_TEXT', 'TOBACO'],
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+    ],
+    'asset_policy_summary_approval_status': [
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+    ],
+    'campaign_id': [1, 1, 1],
+    'campaign_status': ['ENABLED', 'ENABLED', 'ENABLED'],
+    'ad_group_id': [1, 2, 3],
+    'ad_group_status': ['ENABLED', 'ENABLED', 'ENABLED'],
+}
+
+TEST_CAMPAIGN_ASSET_POLICY_DATA = {
+    'event_date': ['2023-10-26', '2023-10-26', '2023-10-26'],
+    'customer_id': [12345, 12345, 12345],
+    'customer_descriptive_name': ['Customer A', 'Customer A', 'Customer A'],
+    'asset_id': [22, 22, 22],
+    'asset_source': ['ADVERTISER', 'ADVERTISER', 'ADVERTISER'],
+    'asset_type': ['CALLOUT', 'CALLOUT', 'CALLOUT'],
+    'asset_policy_summary_review_status': ['REVIEWED', 'REVIEWED', 'REVIEWED'],
+    'asset_policy_summary_policy_topic_entries_topics': [
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+    ],
+    'asset_policy_summary_approval_status': [
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+    ],
+    'campaign_id': [1, 2, 3],
+    'campaign_status': ['ENABLED', 'ENABLED', 'ENABLED'],
+}
+
+TEST_CUSTOMER_ASSET_POLICY_DATA = {
+    'event_date': ['2023-10-26', '2023-10-26', '2023-10-26'],
+    'customer_id': [12345, 12345, 12345],
+    'customer_descriptive_name': ['Customer A', 'Customer A', 'Customer A'],
+    'asset_id': [13, 23, 33],
+    'asset_source': ['ADVERTISER', 'ADVERTISER', 'ADVERTISER'],
+    'asset_type': ['CALLOUT', 'CALLOUT', 'CALLOUT'],
+    'asset_policy_summary_review_status': ['REVIEWED', 'REVIEWED', 'REVIEWED'],
+    'asset_policy_summary_policy_topic_entries_topics': [
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+    ],
+    'asset_policy_summary_approval_status': [
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+    ],
+}
+
+TEST_EXPECTED_ASSET_POLICY_REPORT = {
+    'event_date': [
+        '2023-10-26',
+        '2023-10-26',
+        '2023-10-26',
+        '2023-10-26',
+        '2023-10-26',
+        '2023-10-26',
+    ],
+    'customer_id': [12345, 12345, 12345, 12345, 12345, 12345],
+    'customer_descriptive_name': [
+        'Customer A',
+        'Customer A',
+        'Customer A',
+        'Customer A',
+        'Customer A',
+        'Customer A',
+    ],
+    'asset_id': [11, 21, 22, 13, 23, 33],
+    'asset_source': [
+        'ADVERTISER',
+        'ADVERTISER',
+        'ADVERTISER',
+        'ADVERTISER',
+        'ADVERTISER',
+        'ADVERTISER',
+    ],
+    'asset_type': [
+        'CALLOUT',
+        'CALLOUT',
+        'CALLOUT',
+        'CALLOUT',
+        'CALLOUT',
+        'CALLOUT',
+    ],
+    'asset_policy_summary_review_status': [
+        'REVIEWED',
+        'REVIEWED',
+        'REVIEWED',
+        'REVIEWED',
+        'REVIEWED',
+        'REVIEWED',
+    ],
+    'asset_policy_summary_policy_topic_entries_topics': [
+        'TRADEMARKS_IN_AD_TEXT | TOBACO',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+    ],
+    'asset_policy_summary_approval_status': [
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+    ],
+    'asset_level': [
+        'Ad Group',
+        'Ad Group',
+        'Campaign',
+        'Account',
+        'Account',
+        'Account',
+    ],
+    'counts': [1, 2, 3, 1, 1, 1],
+}

--- a/cloud_functions/ads_policy_monitor/test_data_helper.py
+++ b/cloud_functions/ads_policy_monitor/test_data_helper.py
@@ -148,3 +148,34 @@ TEST_EXPECTED_ASSET_POLICY_REPORT = {
     ],
     'counts': [1, 2, 3, 1, 1, 1],
 }
+
+TEST_CUSTOMER_ASSET_POLICY_DATA_EMPTY = {
+    'event_date': ['2023-10-26'],
+    'customer_id': [0],
+    'customer_descriptive_name': [''],
+    'asset_id': [0],
+    'asset_source': ['UNSPECIFIED'],
+    'asset_type': ['UNSPECIFIED'],
+    'asset_policy_summary_review_status': ['UNSPECIFIED'],
+    'asset_policy_summary_policy_topic_entries_topics': [''],
+    'asset_policy_summary_approval_status': ['UNSPECIFIED']
+}
+
+TEST_EXPECTED_ASSET_POLICY_REPORT_EMPTY_CUSTOMER = {
+    'event_date': ['2023-10-26', '2023-10-26', '2023-10-26'],
+    'customer_id': [12345, 12345, 12345],
+    'customer_descriptive_name': ['Customer A', 'Customer A', 'Customer A'],
+    'asset_id': [11, 21, 22],
+    'asset_source': ['ADVERTISER', 'ADVERTISER', 'ADVERTISER'],
+    'asset_type': ['CALLOUT', 'CALLOUT', 'CALLOUT'],
+    'asset_policy_summary_review_status': ['REVIEWED', 'REVIEWED', 'REVIEWED'],
+    'asset_policy_summary_policy_topic_entries_topics': [
+        'TRADEMARKS_IN_AD_TEXT | TOBACO', 'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT'
+    ],
+    'asset_policy_summary_approval_status': [
+        'APPROVED_LIMITED', 'APPROVED_LIMITED', 'APPROVED_LIMITED'
+    ],
+    'asset_level': ['Ad Group', 'Ad Group', 'Campaign'],
+    'counts': [1, 2, 3],
+}

--- a/cloud_functions/ads_policy_monitor/test_data_helper.py
+++ b/cloud_functions/ads_policy_monitor/test_data_helper.py
@@ -1,0 +1,150 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Constants file for unit tests"""
+
+TEST_AD_GROUP_ASSET_POLICY_DATA = {
+    'event_date': ['2023-10-26', '2023-10-26', '2023-10-26'],
+    'customer_id': [12345, 12345, 12345],
+    'customer_descriptive_name': ['Customer A', 'Customer A', 'Customer A'],
+    'asset_id': [11, 21, 21],
+    'asset_source': ['ADVERTISER', 'ADVERTISER', 'ADVERTISER'],
+    'asset_type': ['CALLOUT', 'CALLOUT', 'CALLOUT'],
+    'asset_policy_summary_review_status': ['REVIEWED', 'REVIEWED', 'REVIEWED'],
+    'asset_policy_summary_policy_topic_entries_topics': [
+        ['TRADEMARKS_IN_AD_TEXT', 'TOBACO'],
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+    ],
+    'asset_policy_summary_approval_status': [
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+    ],
+    'campaign_id': [1, 1, 1],
+    'campaign_status': ['ENABLED', 'ENABLED', 'ENABLED'],
+    'ad_group_id': [1, 2, 3],
+    'ad_group_status': ['ENABLED', 'ENABLED', 'ENABLED'],
+}
+
+TEST_CAMPAIGN_ASSET_POLICY_DATA = {
+    'event_date': ['2023-10-26', '2023-10-26', '2023-10-26'],
+    'customer_id': [12345, 12345, 12345],
+    'customer_descriptive_name': ['Customer A', 'Customer A', 'Customer A'],
+    'asset_id': [22, 22, 22],
+    'asset_source': ['ADVERTISER', 'ADVERTISER', 'ADVERTISER'],
+    'asset_type': ['CALLOUT', 'CALLOUT', 'CALLOUT'],
+    'asset_policy_summary_review_status': ['REVIEWED', 'REVIEWED', 'REVIEWED'],
+    'asset_policy_summary_policy_topic_entries_topics': [
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+    ],
+    'asset_policy_summary_approval_status': [
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+    ],
+    'campaign_id': [1, 2, 3],
+    'campaign_status': ['ENABLED', 'ENABLED', 'ENABLED'],
+}
+
+TEST_CUSTOMER_ASSET_POLICY_DATA = {
+    'event_date': ['2023-10-26', '2023-10-26', '2023-10-26'],
+    'customer_id': [12345, 12345, 12345],
+    'customer_descriptive_name': ['Customer A', 'Customer A', 'Customer A'],
+    'asset_id': [13, 23, 33],
+    'asset_source': ['ADVERTISER', 'ADVERTISER', 'ADVERTISER'],
+    'asset_type': ['CALLOUT', 'CALLOUT', 'CALLOUT'],
+    'asset_policy_summary_review_status': ['REVIEWED', 'REVIEWED', 'REVIEWED'],
+    'asset_policy_summary_policy_topic_entries_topics': [
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+    ],
+    'asset_policy_summary_approval_status': [
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+    ],
+}
+
+TEST_EXPECTED_ASSET_POLICY_REPORT = {
+    'event_date': [
+        '2023-10-26',
+        '2023-10-26',
+        '2023-10-26',
+        '2023-10-26',
+        '2023-10-26',
+        '2023-10-26',
+    ],
+    'customer_id': [12345, 12345, 12345, 12345, 12345, 12345],
+    'customer_descriptive_name': [
+        'Customer A',
+        'Customer A',
+        'Customer A',
+        'Customer A',
+        'Customer A',
+        'Customer A',
+    ],
+    'asset_id': [11, 21, 22, 13, 23, 33],
+    'asset_source': [
+        'ADVERTISER',
+        'ADVERTISER',
+        'ADVERTISER',
+        'ADVERTISER',
+        'ADVERTISER',
+        'ADVERTISER',
+    ],
+    'asset_type': [
+        'CALLOUT',
+        'CALLOUT',
+        'CALLOUT',
+        'CALLOUT',
+        'CALLOUT',
+        'CALLOUT',
+    ],
+    'asset_policy_summary_review_status': [
+        'REVIEWED',
+        'REVIEWED',
+        'REVIEWED',
+        'REVIEWED',
+        'REVIEWED',
+        'REVIEWED',
+    ],
+    'asset_policy_summary_policy_topic_entries_topics': [
+        'TRADEMARKS_IN_AD_TEXT | TOBACO',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
+    ],
+    'asset_policy_summary_approval_status': [
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
+    ],
+    'asset_level': [
+        'Ad Group',
+        'Ad Group',
+        'Campaign',
+        'Account',
+        'Account',
+        'Account',
+    ],
+    'counts': [1, 2, 3, 1, 1, 1],
+}


### PR DESCRIPTION
Getting assets from Campaigns, Ad Groups and Account levels, to get more accurate information on asset usage.

Adding the Asset level and in count of live asset uses per level.