### PR TITLE
Timeseries

### DIFF
--- a/bigquery/schema/ad_policy_time_series_schema.json
+++ b/bigquery/schema/ad_policy_time_series_schema.json
@@ -1,0 +1,17 @@
+[
+    {
+      "name": "event_date",
+      "type": "STRING",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "ad_group_ad_policy_summary_approval_status",
+      "type": "STRING",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "counts",
+      "type": "INTEGER",
+      "mode": "NULLABLE"
+    }
+]

--- a/bigquery/schema/asset_policy_time_series_schema.json
+++ b/bigquery/schema/asset_policy_time_series_schema.json
@@ -1,0 +1,17 @@
+[
+    {
+      "name": "event_date",
+      "type": "STRING",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "asset_policy_summary_approval_status",
+      "type": "STRING",
+      "mode": "NULLABLE"
+    },
+    {
+      "name": "counts",
+      "type": "INTEGER",
+      "mode": "NULLABLE"
+    }
+]

--- a/cloud_functions/ads_policy_monitor/bigquery.py
+++ b/cloud_functions/ads_policy_monitor/bigquery.py
@@ -27,16 +27,18 @@ def write_gaarf_report_to_bigquery(
         payload: models.Payload,
         gaarf_report: GaarfReport,
         report_config: models.ReportConfig,
+        table_name: str,
         bq_writer: writer.BigQueryWriter = None) -> None:
     """Output a GAARF report to BigQuery.
 
     Args:
         payload: the configuration used in this execution.
-        gaarf_report: the report to output
+        gaarf_report: the report to output.
         report_config: the config of the report to run.
+        table_name: name of the table to write to.
         bq_writer: for dependency injection, provide a BQ writer class.
     """
-    logger.info('Writing report to BigQuery: %s', report_config.table_name)
+    logger.info('Writing report to BigQuery: %s', table_name)
     if bq_writer is None:
         bq_writer = writer.BigQueryWriter(
             project=payload.project_id,
@@ -44,4 +46,4 @@ def write_gaarf_report_to_bigquery(
             location=payload.region,
             write_disposition=report_config.write_disposition)
 
-    bq_writer.write(gaarf_report, destination=report_config.table_name)
+    bq_writer.write(gaarf_report, destination=table_name)

--- a/cloud_functions/ads_policy_monitor/bigquery_test.py
+++ b/cloud_functions/ads_policy_monitor/bigquery_test.py
@@ -24,12 +24,12 @@ class BigQueryTestCase(unittest.TestCase):
         mock_bq_writer = MagicMock()
         mock_gaarf_report = MagicMock()
         mock_report_config = MagicMock()
-        mock_report_config.table_name.return_value = 'table_name'
+        table_name = 'table_name'
         bigquery.write_gaarf_report_to_bigquery(mock_payload, mock_gaarf_report,
-                                                mock_report_config,
+                                                mock_report_config, table_name,
                                                 mock_bq_writer)
-        mock_bq_writer.write.assert_called_with(
-            mock_gaarf_report, destination=mock_report_config.table_name)
+        mock_bq_writer.write.assert_called_with(mock_gaarf_report,
+                                                destination=table_name)
 
 
 if __name__ == '__main__':

--- a/cloud_functions/ads_policy_monitor/config.json
+++ b/cloud_functions/ads_policy_monitor/config.json
@@ -8,12 +8,16 @@
     },
     {
       "table_name": "AdPolicyData",
+      "time_series_table_name": "AdPolicyDataTimeSeries",
+      "time_series_variable_column": "ad_group_ad_policy_summary_approval_status",
       "write_disposition": "WRITE_APPEND",
       "is_builtin": false,
       "gaql_filenames": "ad_policy_data.sql"
     },
     {
       "table_name": "AssetPolicyData",
+      "time_series_table_name": "AssetPolicyDataTimeSeries",
+      "time_series_variable_column": "asset_policy_summary_approval_status",
       "write_disposition": "WRITE_APPEND",
       "is_builtin": false,
       "is_asset_report": true,

--- a/cloud_functions/ads_policy_monitor/google_ads_test.py
+++ b/cloud_functions/ads_policy_monitor/google_ads_test.py
@@ -26,6 +26,7 @@ from test_data_helper import TEST_CUSTOMER_ASSET_POLICY_DATA
 from test_data_helper import TEST_EXPECTED_ASSET_POLICY_REPORT
 from test_data_helper import TEST_CUSTOMER_ASSET_POLICY_DATA_EMPTY
 from test_data_helper import TEST_EXPECTED_ASSET_POLICY_REPORT_EMPTY_CUSTOMER
+from test_data_helper import TEST_EXPECTED_TIME_SERIES
 from gaarf.report import GaarfReport
 
 import google_ads
@@ -138,6 +139,19 @@ class GoogleAdsTestCase(unittest.TestCase):
 
         results = report.to_pandas()
         expected_results = GaarfReport.from_pandas(pd.DataFrame()).to_pandas()
+        assert_frame_equal(results, expected_results)
+
+    def test_extract_time_series(self):
+        mock_report_config = MagicMock()
+        mock_report_config.time_series_variable_column = 'asset_policy_summary_approval_status'
+        assets_report = GaarfReport.from_pandas(
+            pd.DataFrame(TEST_CAMPAIGN_ASSET_POLICY_DATA))
+
+        timeseries = google_ads.extract_time_series(assets_report,
+                                                    mock_report_config)
+
+        results = timeseries.to_pandas()
+        expected_results = pd.DataFrame(TEST_EXPECTED_TIME_SERIES)
         assert_frame_equal(results, expected_results)
 
 

--- a/cloud_functions/ads_policy_monitor/main.py
+++ b/cloud_functions/ads_policy_monitor/main.py
@@ -133,7 +133,16 @@ def run(payload: models.Payload) -> None:
             logger.warning('GAARF report is None, check configuration.')
             return None
         bigquery.write_gaarf_report_to_bigquery(payload, gaarf_report,
-                                                report_config)
+                                                report_config,
+                                                report_config.table_name)
+
+        if report_config.time_series_table_name:
+            report_time_series = google_ads.extract_time_series(
+                gaarf_report, report_config)
+            bigquery.write_gaarf_report_to_bigquery(
+                payload, report_time_series, report_config,
+                report_config.time_series_table_name)
+
     logger.info('Done.')
 
 

--- a/cloud_functions/ads_policy_monitor/models.py
+++ b/cloud_functions/ads_policy_monitor/models.py
@@ -23,6 +23,8 @@ class ReportConfig(BaseModel):
     is_asset_report: bool = False
     builtin_query_name: Optional[str] = None
     gaql_filenames: Optional[Union[str, List[str]]] = None
+    time_series_table_name: Optional[str] = None
+    time_series_variable_column: Optional[str] = None
 
 
 class Payload(BaseModel):

--- a/cloud_functions/ads_policy_monitor/test_data_helper.py
+++ b/cloud_functions/ads_policy_monitor/test_data_helper.py
@@ -38,14 +38,19 @@ TEST_AD_GROUP_ASSET_POLICY_DATA = {
 }
 
 TEST_CAMPAIGN_ASSET_POLICY_DATA = {
-    'event_date': ['2023-10-26', '2023-10-26', '2023-10-26'],
-    'customer_id': [12345, 12345, 12345],
-    'customer_descriptive_name': ['Customer A', 'Customer A', 'Customer A'],
-    'asset_id': [22, 22, 22],
-    'asset_source': ['ADVERTISER', 'ADVERTISER', 'ADVERTISER'],
-    'asset_type': ['CALLOUT', 'CALLOUT', 'CALLOUT'],
-    'asset_policy_summary_review_status': ['REVIEWED', 'REVIEWED', 'REVIEWED'],
+    'event_date': ['2023-10-26', '2023-10-26', '2023-10-26', '2023-10-27'],
+    'customer_id': [12345, 12345, 12345, 12345],
+    'customer_descriptive_name': [
+        'Customer A', 'Customer A', 'Customer A', 'Customer A'
+    ],
+    'asset_id': [22, 22, 22, 22],
+    'asset_source': ['ADVERTISER', 'ADVERTISER', 'ADVERTISER', 'ADVERTISER'],
+    'asset_type': ['CALLOUT', 'CALLOUT', 'CALLOUT', 'CALLOUT'],
+    'asset_policy_summary_review_status': [
+        'REVIEWED', 'REVIEWED', 'REVIEWED', 'REVIEWED'
+    ],
     'asset_policy_summary_policy_topic_entries_topics': [
+        'TRADEMARKS_IN_AD_TEXT',
         'TRADEMARKS_IN_AD_TEXT',
         'TRADEMARKS_IN_AD_TEXT',
         'TRADEMARKS_IN_AD_TEXT',
@@ -54,9 +59,10 @@ TEST_CAMPAIGN_ASSET_POLICY_DATA = {
         'APPROVED_LIMITED',
         'APPROVED_LIMITED',
         'APPROVED_LIMITED',
+        'APPROVED_LIMITED',
     ],
-    'campaign_id': [1, 2, 3],
-    'campaign_status': ['ENABLED', 'ENABLED', 'ENABLED'],
+    'campaign_id': [1, 2, 3, 3],
+    'campaign_status': ['ENABLED', 'ENABLED', 'ENABLED', 'ENABLED'],
 }
 
 TEST_CUSTOMER_ASSET_POLICY_DATA = {
@@ -84,11 +90,12 @@ TEST_EXPECTED_ASSET_POLICY_REPORT = {
         '2023-10-26',
         '2023-10-26',
         '2023-10-26',
+        '2023-10-27',
         '2023-10-26',
         '2023-10-26',
         '2023-10-26',
     ],
-    'customer_id': [12345, 12345, 12345, 12345, 12345, 12345],
+    'customer_id': [12345, 12345, 12345, 12345, 12345, 12345, 12345],
     'customer_descriptive_name': [
         'Customer A',
         'Customer A',
@@ -96,9 +103,11 @@ TEST_EXPECTED_ASSET_POLICY_REPORT = {
         'Customer A',
         'Customer A',
         'Customer A',
+        'Customer A',
     ],
-    'asset_id': [11, 21, 22, 13, 23, 33],
+    'asset_id': [11, 21, 22, 22, 13, 23, 33],
     'asset_source': [
+        'ADVERTISER',
         'ADVERTISER',
         'ADVERTISER',
         'ADVERTISER',
@@ -113,8 +122,10 @@ TEST_EXPECTED_ASSET_POLICY_REPORT = {
         'CALLOUT',
         'CALLOUT',
         'CALLOUT',
+        'CALLOUT',
     ],
     'asset_policy_summary_review_status': [
+        'REVIEWED',
         'REVIEWED',
         'REVIEWED',
         'REVIEWED',
@@ -129,8 +140,10 @@ TEST_EXPECTED_ASSET_POLICY_REPORT = {
         'TRADEMARKS_IN_AD_TEXT',
         'TRADEMARKS_IN_AD_TEXT',
         'TRADEMARKS_IN_AD_TEXT',
+        'TRADEMARKS_IN_AD_TEXT',
     ],
     'asset_policy_summary_approval_status': [
+        'APPROVED_LIMITED',
         'APPROVED_LIMITED',
         'APPROVED_LIMITED',
         'APPROVED_LIMITED',
@@ -142,11 +155,12 @@ TEST_EXPECTED_ASSET_POLICY_REPORT = {
         'Ad Group',
         'Ad Group',
         'Campaign',
+        'Campaign',
         'Account',
         'Account',
         'Account',
     ],
-    'counts': [1, 2, 3, 1, 1, 1],
+    'counts': [1, 2, 3, 1, 1, 1, 1],
 }
 
 TEST_CUSTOMER_ASSET_POLICY_DATA_EMPTY = {
@@ -162,20 +176,33 @@ TEST_CUSTOMER_ASSET_POLICY_DATA_EMPTY = {
 }
 
 TEST_EXPECTED_ASSET_POLICY_REPORT_EMPTY_CUSTOMER = {
-    'event_date': ['2023-10-26', '2023-10-26', '2023-10-26'],
-    'customer_id': [12345, 12345, 12345],
-    'customer_descriptive_name': ['Customer A', 'Customer A', 'Customer A'],
-    'asset_id': [11, 21, 22],
-    'asset_source': ['ADVERTISER', 'ADVERTISER', 'ADVERTISER'],
-    'asset_type': ['CALLOUT', 'CALLOUT', 'CALLOUT'],
-    'asset_policy_summary_review_status': ['REVIEWED', 'REVIEWED', 'REVIEWED'],
+    'event_date': ['2023-10-26', '2023-10-26', '2023-10-26', '2023-10-27'],
+    'customer_id': [12345, 12345, 12345, 12345],
+    'customer_descriptive_name': [
+        'Customer A', 'Customer A', 'Customer A', 'Customer A'
+    ],
+    'asset_id': [11, 21, 22, 22],
+    'asset_source': ['ADVERTISER', 'ADVERTISER', 'ADVERTISER', 'ADVERTISER'],
+    'asset_type': ['CALLOUT', 'CALLOUT', 'CALLOUT', 'CALLOUT'],
+    'asset_policy_summary_review_status': [
+        'REVIEWED', 'REVIEWED', 'REVIEWED', 'REVIEWED'
+    ],
     'asset_policy_summary_policy_topic_entries_topics': [
         'TRADEMARKS_IN_AD_TEXT | TOBACO', 'TRADEMARKS_IN_AD_TEXT',
-        'TRADEMARKS_IN_AD_TEXT'
+        'TRADEMARKS_IN_AD_TEXT', 'TRADEMARKS_IN_AD_TEXT'
     ],
     'asset_policy_summary_approval_status': [
-        'APPROVED_LIMITED', 'APPROVED_LIMITED', 'APPROVED_LIMITED'
+        'APPROVED_LIMITED', 'APPROVED_LIMITED', 'APPROVED_LIMITED',
+        'APPROVED_LIMITED'
     ],
-    'asset_level': ['Ad Group', 'Ad Group', 'Campaign'],
-    'counts': [1, 2, 3],
+    'asset_level': ['Ad Group', 'Ad Group', 'Campaign', 'Campaign'],
+    'counts': [1, 2, 3, 1],
+}
+
+TEST_EXPECTED_TIME_SERIES = {
+    'event_date': ['2023-10-26', '2023-10-27'],
+    'asset_policy_summary_approval_status': [
+        'APPROVED_LIMITED', 'APPROVED_LIMITED'
+    ],
+    'counts': [3, 1]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -51,6 +51,14 @@ resource "google_bigquery_table" "ad_policy_data_table" {
   }
 }
 
+resource "google_bigquery_table" "ad_policy_time_series_table" {
+  dataset_id          = google_bigquery_dataset.dataset.dataset_id
+  table_id            = "AdPolicyTimeSeries"
+  deletion_protection = false
+  schema              = file("../bigquery/schema/ad_policy_time_series_schema.json")
+  labels              = local.labels
+}
+
 resource "google_bigquery_table" "asset_policy_data_table" {
   dataset_id          = google_bigquery_dataset.dataset.dataset_id
   table_id            = "AssetPolicyData"
@@ -61,6 +69,14 @@ resource "google_bigquery_table" "asset_policy_data_table" {
     type          = "DAY"
     expiration_ms = 86400000 * var.bq_expiration_days
   }
+}
+
+resource "google_bigquery_table" "asset_policy_time_series_table" {
+  dataset_id          = google_bigquery_dataset.dataset.dataset_id
+  table_id            = "AssetPolicyTimeSeries"
+  deletion_protection = false
+  schema              = file("../bigquery/schema/asset_policy_time_series_schema.json")
+  labels              = local.labels
 }
 
 resource "google_bigquery_table" "ocid_table" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,7 +52,7 @@ variable "customer_ids" {
 variable "bq_expiration_days" {
   type        = number
   description = "The number of days to keep data in a BigQuery partition."
-  default     = 90
+  default     = 3
 }
 
 variable "use_synthetic_data" {


### PR DESCRIPTION
Improving cloud costs and dashboard load time by extracting time series from the reports, and only storing the full report data for 3 days. 