### PR TITLE
Updaging Google Ads API version to v16

### DIFF
--- a/cloud_functions/ads_policy_monitor/google_ads.py
+++ b/cloud_functions/ads_policy_monitor/google_ads.py
@@ -33,7 +33,7 @@ logging.basicConfig(stream=sys.stdout)
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-GOOGLE_ADS_API_VERSION = 'v14'
+GOOGLE_ADS_API_VERSION = 'v16'
 
 GOOGLE_ADS_REFRESH_TOKEN = os.environ.get('GOOGLE_ADS_REFRESH_TOKEN')
 GOOGLE_ADS_CLIENT_ID = os.environ.get('GOOGLE_ADS_CLIENT_ID')

--- a/cloud_functions/ads_policy_monitor/requirements.txt
+++ b/cloud_functions/ads_policy_monitor/requirements.txt
@@ -1,5 +1,5 @@
 functions-framework==3.*
-google-ads-api-report-fetcher==1.11.5
+google-ads-api-report-fetcher[bq]==1.13.4
 numpy==1.26.1
 jsonschema==4.19.1
 pydantic==2.4.2


### PR DESCRIPTION
Fixing "ModuleNotFoundError: No module named 'google.ads.googleads.v14'" error