### PR TITLE
populate 0 for null valued asset reports, to fix no-write bug

### DIFF
--- a/cloud_functions/ads_policy_monitor/google_ads.py
+++ b/cloud_functions/ads_policy_monitor/google_ads.py
@@ -173,8 +173,12 @@ def combine_assets_reports(gaarf_reports: List[GaarfReport]) -> GaarfReport:
 
         combined_assets_report = pd.concat([combined_assets_report, report_df])
 
-    combined_assets_report['example_campaign_id'] = combined_assets_report['example_campaign_id'].fillna(0)
-    combined_assets_report['example_ad_group_id'] = combined_assets_report['example_ad_group_id'].fillna(0)
+    if ('example_campaign_id' in combined_assets_report.keys() or
+            'example_ad_group_id' in combined_assets_report.keys()):
+        combined_assets_report['example_campaign_id'] = combined_assets_report[
+            'example_campaign_id'].fillna(0)
+        combined_assets_report['example_ad_group_id'] = combined_assets_report[
+            'example_ad_group_id'].fillna(0)
 
     return GaarfReport.from_pandas(combined_assets_report)
 

--- a/cloud_functions/ads_policy_monitor/google_ads.py
+++ b/cloud_functions/ads_policy_monitor/google_ads.py
@@ -173,6 +173,9 @@ def combine_assets_reports(gaarf_reports: List[GaarfReport]) -> GaarfReport:
 
         combined_assets_report = pd.concat([combined_assets_report, report_df])
 
+    combined_assets_report['example_campaign_id'] = combined_assets_report['example_campaign_id'].fillna(0)
+    combined_assets_report['example_ad_group_id'] = combined_assets_report['example_ad_group_id'].fillna(0)
+
     return GaarfReport.from_pandas(combined_assets_report)
 
 

--- a/cloud_functions/ads_policy_monitor/test_data_helper.py
+++ b/cloud_functions/ads_policy_monitor/test_data_helper.py
@@ -160,8 +160,8 @@ TEST_EXPECTED_ASSET_POLICY_REPORT = {
         'Account',
         'Account',
     ],
-    'example_campaign_id': [1, 1, 1, 3, None, None, None],
-    'example_ad_group_id': [1, 2, None, None, None, None, None],
+    'example_campaign_id': [1, 1, 1, 3, 0, 0, 0],
+    'example_ad_group_id': [1, 2, 0, 0, 0, 0, 0],
     'counts': [1, 2, 3, 1, 1, 1, 1]
 }
 
@@ -199,7 +199,7 @@ TEST_EXPECTED_ASSET_POLICY_REPORT_EMPTY_CUSTOMER = {
     ],
     'asset_level': ['Ad Group', 'Ad Group', 'Campaign', 'Campaign'],
     'example_campaign_id': [1, 1, 1, 3],
-    'example_ad_group_id': [1, 2, None, None],
+    'example_ad_group_id': [1, 2, 0, 0],
     'counts': [1, 2, 3, 1]
 }
 


### PR DESCRIPTION
Fix following a client bug - seeing no values in the AssetPolicyData table.
when combining the asset reports, the account asset report doesn't have a value for example_campaign_id and example_adgroup_id,  and the campaign asset report doesn't have values for example_adgroup_id. what can happen is a mix of value types in these columns - null and integers. when this happens, for some reason we get no error but the rows are not written to the table. to remedy this, i used fillna(0) so where there are no values there will be a 0 instead of null. (this corresponds to the synthetic data where no values is populated with 0)